### PR TITLE
Pagination for blog and tools

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,19 +1,13 @@
   
 {% assign paginator = include.paginator %}
 
-<div class="pagination">
-  {% if paginator.total_pages > 1 %}
-    <ul>
-      {% if paginator.previous_page %}
-      <li>
-        <a href="{{ paginator.previous_page_path | prepend: site.baseurl }}">Newer</a>
-      </li>
-      {% endif %}
-      {% if paginator.next_page %}
-      <li>
-        <a href="{{ paginator.next_page_path | prepend: site.baseurl }}">Older</a>
-      </li>
-      {% endif %}
-    </ul>
+{% if paginator.total_pages > 1 %}
+<div class="post-navigation">
+  {% if paginator.previous_page %}
+  <a class="prev" href="{{ paginator.previous_page_path | prepend: site.baseurl }}">Newer {{ include.type | default: "posts" }}</a>
   {% endif %}
-</div><!-- .pagination -->
+  {% if paginator.next_page %}
+  <a class="next" href="{{ paginator.next_page_path | prepend: site.baseurl }}">Older {{ include.type | default: "posts" }}</a>
+  {% endif %}
+</div><!-- .post-navigation -->
+{% endif %}

--- a/_includes/section_tools.html
+++ b/_includes/section_tools.html
@@ -24,7 +24,7 @@
         </div>
         {% endfor %}
       </div>
-      {% include pagination.html paginator=paginator %}
+      {% include pagination.html paginator=paginator type="tools" %}
       <p class="rss-subscribe">Subscribe to new tools <a href="{{ "/tools/feed.xml" | relative_url }}">via RSS</a></p>
     </div> <!-- .block-content -->
   </div> <!-- .inner -->

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -49,23 +49,8 @@ layout: body
         {% endfor %}
         </div>
       </article><!-- .post -->
-    {% endfor %}
+      {% endfor %}
     </div><!-- .post-feed -->
-    <div class="pagination">
-      {% if paginator.total_pages >  1 %}
-        <ul>
-          {% if paginator.previous_page %}
-          <li>
-            <a href="{{ paginator.previous_page_path | prepend: site.baseurl }}">Newer</a>
-          </li>
-          {% endif %}
-          {% if paginator.next_page %}
-          <li>
-            <a href="{{ paginator.next_page_path | prepend: site.baseurl }}">Older</a>
-          </li>
-          {% endif %}
-        </ul>
-      {% endif %}
-    </div><!-- .pagination -->
+    {% include pagination.html paginator=paginator %}
     <p class="rss-subscribe">Subscribe to new blog posts <a href="{{ "/index.xml" | relative_url }}">via RSS</a></p>
   </div><!-- .inner-md -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -38,5 +38,15 @@ layout: body
         </div>
       </div><!-- .post-content -->
     </div><!-- .inner-md -->
-    <p class="rss-subscribe">Subscribe to new blog posts <a href="{{ "/index.xml" | relative_url }}">via RSS</a></p>
+    <div class="inner outer">
+      <div class="post-navigation">
+        {% if page.next.url %}
+          <a class="prev" href="{{page.next.url}}">{{page.next.title | truncate: 60}}</a>
+        {% endif %}
+        {% if page.previous.url %}
+          <a class="next" href="{{page.previous.url}}">{{page.previous.title | truncate: 60}}</a>
+        {% endif %}
+      </div>
+      <p class="rss-subscribe">Subscribe to new blog posts <a href="{{ "/index.xml" | relative_url }}">via RSS</a></p>
+    </div>
   </article><!-- .post -->

--- a/_sass/imports/_posts.scss
+++ b/_sass/imports/_posts.scss
@@ -151,6 +151,37 @@
   }
 }
 
+.post-navigation {
+  margin-top: 2.5em;
+  display: block;
+  width: auto;
+  overflow: hidden;
+  
+  a {
+    text-decoration: none;
+    border-bottom: none;
+    display: block;
+    width: 50%;
+    float: left;
+    margin: 1em 0;
+  }
+  
+  .prev {
+    &::before {
+      content: "<";
+      margin-right: 6px;
+    }
+  }
+
+  .next {
+    text-align: right;
+    &::after {
+      content: ">";
+      margin-left: 6px;
+    }
+  }
+}
+
 @media only screen and (min-width: 641px) {
   .has-gradient {
     .page-title,


### PR DESCRIPTION
Optimized existing pagination code and added a basic design for older-newer style pagination that's used on the blog and in the tools section. Individual blog posts display titles of older-newer blog posts.

Note: until we have more content, you can test this feature locally by setting `pagination.per_page` in `_config.yml` to a lower number.